### PR TITLE
feat(tooling): auto-discover developer key from VS Code settings

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Builds BatterySafe for epix2pro42mm using the Connect IQ SDK.
-# Developer key is read from $GARMIN_DEVELOPER_KEY or the macOS default location.
+# Developer key discovery order:
+#   1. $GARMIN_DEVELOPER_KEY environment variable
+#   2. monkeyC.developerKeyPath in VS Code user settings (JSONC)
+#   3. macOS standard path
 
 set -e
 
@@ -8,24 +11,53 @@ REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 DEVICE="epix2pro42mm"
 OUTPUT="$REPO_ROOT/bin/BatterySafe-${DEVICE}.prg"
 JUNGLE="$REPO_ROOT/monkey.jungle"
-MACOS_DEFAULT_KEY="$HOME/Library/Application Support/Garmin/ConnectIQ/developer_key.der"
 
-# Check monkeyc availability
+# Overridable for test isolation
+_VSCODE_SETTINGS="${GARMIN_VSCODE_SETTINGS:-$HOME/Library/Application Support/Code/User/settings.json}"
+_STANDARD_KEY="${GARMIN_STANDARD_KEY_PATH:-$HOME/Library/Application Support/Garmin/ConnectIQ/developer_key.der}"
+
 if ! command -v monkeyc &>/dev/null; then
     echo "Error: monkeyc not found in PATH." >&2
     echo "Install the Connect IQ SDK and add its bin/ directory to PATH." >&2
     exit 1
 fi
 
-# Discover developer key
+# Developer key discovery
+KEY=""
+
+# 1. Environment variable
 if [ -n "$GARMIN_DEVELOPER_KEY" ]; then
     KEY="$GARMIN_DEVELOPER_KEY"
-elif [ -f "$MACOS_DEFAULT_KEY" ]; then
-    KEY="$MACOS_DEFAULT_KEY"
-else
+fi
+
+# 2. VS Code settings (monkeyC.developerKeyPath)
+if [ -z "$KEY" ] && [ -f "$_VSCODE_SETTINGS" ] && command -v python3 &>/dev/null; then
+    _vscode_key=$(python3 -c "
+import json, re, sys
+try:
+    raw = open(sys.argv[1]).read()
+    data = re.sub(r'//[^\n]*', '', raw)
+    data = re.sub(r',\s*([}\]])', r'\1', data)
+    print(json.loads(data).get('monkeyC.developerKeyPath', ''))
+except Exception:
+    pass
+" "$_VSCODE_SETTINGS" 2>/dev/null || true)
+    if [ -n "$_vscode_key" ] && [ -f "$_vscode_key" ]; then
+        KEY="$_vscode_key"
+    fi
+fi
+
+# 3. macOS standard path
+if [ -z "$KEY" ] && [ -f "$_STANDARD_KEY" ]; then
+    KEY="$_STANDARD_KEY"
+fi
+
+if [ -z "$KEY" ]; then
     echo "Error: developer key not found." >&2
-    echo "Set \$GARMIN_DEVELOPER_KEY or place your key at:" >&2
-    echo "  $MACOS_DEFAULT_KEY" >&2
+    echo "Provide the key via one of:" >&2
+    echo "  1. \$GARMIN_DEVELOPER_KEY environment variable" >&2
+    echo "  2. monkeyC.developerKeyPath in VS Code user settings" >&2
+    echo "  3. $_STANDARD_KEY" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Closes #18

## Summary

- Adds VS Code settings as a second key discovery step in `build.sh`, between `$GARMIN_DEVELOPER_KEY` and the macOS standard path
- Discovery order: `$GARMIN_DEVELOPER_KEY` → VS Code `monkeyC.developerKeyPath` → macOS standard path → fail with clear error
- JSONC parsing via `python3` (pre-installed on macOS): strips `//` comments and trailing commas via regex before `json.loads` — any parse failure silently falls through to step 3
- Both `_VSCODE_SETTINGS` and `_STANDARD_KEY` paths are overridable via `GARMIN_VSCODE_SETTINGS` / `GARMIN_STANDARD_KEY_PATH` env vars for test isolation without touching `~/Library`
- Error message updated to mention all three discovery methods

## Test results (executed by Claude Code)

**Test a — `$GARMIN_DEVELOPER_KEY` set → env var wins (regression)**
```
Device : epix2pro42mm
Key    : /Users/matteodeias/Documents/Progetti/garmin/RecoveryFace/developer_key
...
BUILD SUCCESSFUL
```
Exit code: **0** ✓

**Test b — `$GARMIN_DEVELOPER_KEY=""` → VS Code settings wins**
```
Device : epix2pro42mm
Key    : /Users/matteodeias/Documents/Progetti/garmin/RecoveryFace/developer_key
...
BUILD SUCCESSFUL
```
Exit code: **0** ✓ — key sourced from `monkeyC.developerKeyPath` in VS Code settings (same physical file)

**Test c — VS Code → `/tmp/empty_settings.json` (no key), macOS standard → `/tmp/fake_key.der` (empty file)**
```
Device : epix2pro42mm
Key    : /tmp/fake_key.der
...
ERROR: Unable to load private key: java.security.InvalidKeyException: Missing key encoding
```
Discovery: **correct** ✓ — `Key:` line shows `/tmp/fake_key.der`, confirming step 3 fired. `monkeyc` then fails on the empty file as expected (key validation is `monkeyc`'s responsibility, not `build.sh`'s).

**Test d — all methods fail**
```
Error: developer key not found.
Provide the key via one of:
  1. $GARMIN_DEVELOPER_KEY environment variable
  2. monkeyC.developerKeyPath in VS Code user settings
  3. /tmp/nonexistent_key.der
```
Exit code: **1** ✓ — all three methods mentioned in error output

## Acceptance criteria

- [x] `monkeyC.developerKeyPath` in VS Code settings used when set
- [x] JSONC-safe parsing (comments, trailing commas)
- [x] Graceful fallback if VS Code not installed or `settings.json` missing
- [x] Priority order preserved: `$GARMIN_DEVELOPER_KEY` still wins
- [x] macOS standard path still works as final fallback
- [x] Error message mentions all three discovery methods
- [x] Discovered path validated as existing file before use

🤖 Generated with [Claude Code](https://claude.com/claude-code)