### PR TITLE
fix(data): persist lastChargeEndTs across watchface reloads

### DIFF
--- a/source/core/State.mc
+++ b/source/core/State.mc
@@ -90,7 +90,7 @@ class State {
         devBattery        = null;
         devBatteryStr     = BATT_FALLBACK;
         hasRealDevBattery = false;
-        charging          = false;
+        charging          = null;
 
         // tracking
         lastBattSamplePct = null;

--- a/source/manager/DataManager.mc
+++ b/source/manager/DataManager.mc
@@ -1,3 +1,4 @@
+using Toybox.Application;
 using Toybox.System;
 using Toybox.Time;
 using Toybox.Math;
@@ -17,6 +18,19 @@ class DataManager {
 
     function initialize(state as State) {
         _state = state;
+
+        // Restore lastChargeEndTs across reloads: stored as epoch (seconds),
+        // converted back to System.getTimer() units on resume.
+        try {
+            var storedEpoch = Application.Storage.getValue("lastChargeEndEpoch");
+            if (storedEpoch != null) {
+                var nowMs = System.getTimer();
+                var elapsedMs = (Time.now().value() - storedEpoch) * 1000;
+                if (elapsedMs > 0 && elapsedMs < 20 * 24 * 3600 * 1000) {
+                    _state.lastChargeEndTs = nowMs - elapsedMs;
+                }
+            }
+        } catch(e) {}
 
         // Date iniziale
         refreshDateIfNeeded();
@@ -162,6 +176,7 @@ class DataManager {
         } else {
             // esce da charging (unplug)
             _state.lastChargeEndTs = nowMs;
+            Application.Storage.setValue("lastChargeEndEpoch", Time.now().value());
 
             if (_state.chargeStartTs != 0 && nowMs > _state.chargeStartTs) {
                 _state.lastChargeDurMs = nowMs - _state.chargeStartTs;


### PR DESCRIPTION
Closes #23

## Root cause

`lastChargeEndTs` in `State` is volatile RAM. It is set correctly when the
charger is unplugged **during the current session**, but is reset to `0` on
every watchface reload — causing the header to permanently show
`"Since charge: --"` unless the user happens to unplug the charger while
the watchface is already running.

Secondary bug: `State.initialize()` set `charging = false` instead of
`null`, making the null-guard `if (_state.charging == null)` in
`handleChargingTransitions` dead code. A false chargeStartTs could be
recorded on boot when the device was already charging.

## Fix

**`source/manager/DataManager.mc`**

- Add `using Toybox.Application;`
- On unplug transition: `Application.Storage.setValue("lastChargeEndEpoch", Time.now().value())`
- In `DataManager.initialize()`: read stored epoch, convert to
  `System.getTimer()` units and restore `_state.lastChargeEndTs`.
  Guard: only restore if `0 < elapsedMs < 20 days` (avoids negative
  values and 32-bit overflow).

**`source/core/State.mc`**

- `charging = null` (was `false`) — makes the null-guard reachable on
  first call, so initial charging state is set without triggering a
  spurious transition.

## Quality gate report

Tests executed on `epix2pro42mm`:

- ✅ Build successful (exit 0, `BatterySafe-epix2pro42mm.prg` created)
- ✅ Run cold start (simulator launched, watchface loaded, exit 0)
- ✅ Run warm start (skip auto-launch, watchface reloaded, exit 0)
- ✅ No new compiler warnings (stderr empty)
- ✅ Regression check (build with normal env vars unchanged)

⚠️ **Visual verification required by Matteo before merge**: please
confirm that the watchface renders correctly in the simulator and that
"Since charge:" shows the expected value after a simulated unplug + reload
cycle.

## Notes

- The `Application.Storage` write happens only on unplug transitions
  (rare) — no impact on normal CPU/battery budget.
- Elapsed times older than ~20 days are not restored (32-bit int boundary);
  in practice this is irrelevant for a battery-tracking watchface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)