### PR TITLE
fix(data): use valid format string in _fmtDH to avoid cold start crash

### DIFF
--- a/source/manager/DataManager.mc
+++ b/source/manager/DataManager.mc
@@ -368,9 +368,9 @@ class DataManager {
         min = min % 60;
 
         if (day > 0) {
-            return day.format("%dd") + " " + hr.format("%dh");
+            return day.format("%d") + "d " + hr.format("%d") + "h";
         }
-        return hr.format("%dh") + " " + min.format("%dm");
+        return hr.format("%d") + "h " + min.format("%d") + "m";
     }
 
     function refreshChargingIfNeeded(nowMs) {


### PR DESCRIPTION
## Summary

Fixes #26.

`Number.format()` in Monkey C does **not** tolerate trailing literal characters in the format string. Calls like `day.format("%dd")`, `hr.format("%dh")`, or `min.format("%dm")` throw `Invalid Value — Unexpected input to format` at runtime.

The bug was latent until PR #24 introduced `lastChargeEndEpoch` persistence: prior to that, `_state.lastChargeEndTs` was always `0` at cold start, so `refreshHeaderIfNeeded` skipped the `_fmtDH` call. Once the restore populates a non-zero value, the very first `onUpdate` after a cold start hits the format and crashes the watchface.

The other call site of `_fmtDH` (TOP2_CHG mode) also carried the bug but was apparently never exercised in production (default top2 mode is EFF).

## Root cause confirmed via diagnostics

Temporary `Log.e()` instrumentation was added to capture types and values at cold start. Findings:

- `storedEpoch=1777278171` — `Number`, OK
- `elapsedMs=196320000` (~54h) — `Number`, passes the 20-day guard
- `lastChargeEndTs=-195897148` — negative but **logically correct**: `nowMs - lastChargeEndTs` yields the real elapsed time (`196320000` ms) which is what `_fmtDH` should format
- `_fmtDH` computes `day=2, hr=54, min=3272` — all `Number`
- Crash on `day.format("%dd")` — the format string is the problem, not overflow nor `Long` propagation

After replacing `format("%dd")` → `format("%d") + "d"` (and analogous for `h`, `m`), the cold start completes without crash and the simulator stays running.

The instrumentation was removed after diagnosis — see commit history.

## Fix

Adopt the same pattern already used by `formatTte`: bare `%d` specifier, unit letter concatenated as a separate string fragment.

```diff
-    return day.format("%dd") + " " + hr.format("%dh");
+    return day.format("%d") + "d " + hr.format("%d") + "h";
-    return hr.format("%dh") + " " + min.format("%dm");
+    return hr.format("%d") + "h " + min.format("%d") + "m";
```

Output is byte-identical to the previous intent (e.g. `"2d 6h"`, `"3h 23m"`).

## Quality gate report

Tests executed:
- ✅ Build successful (exit 0, no warnings)
- ✅ Run cold start: simulator launched from quit state, watchface loaded, **no crash** (previously crashed at first `onUpdate`)
- ✅ Run warm start: auto-launch correctly skipped, watchface reloaded, no crash
- ✅ No new compiler warnings

⚠️ **Visual verification required by Matteo before merge**: please confirm in the simulator that the header shows a sensible "Since charge: Xd Yh" or "Since charge: Xh Ym" string after cold start with a non-empty `lastChargeEndEpoch` storage.

## Test plan

- [ ] Cold start with non-empty `lastChargeEndEpoch`: app launches, header shows elapsed time
- [ ] Cold start with empty storage (fresh install): app launches, header shows `--`
- [ ] Plug/unplug cycle in-session: header transitions to elapsed time after unplug
- [ ] Plug/unplug then cold restart: persisted elapsed time survives reload

## Unblocks

Once merged, the quality gate of #25 (refactor) can pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)