### PR TITLE
refactor(data): dedupe getSystemStats and throttle date refresh

### DIFF
--- a/source/core/State.mc
+++ b/source/core/State.mc
@@ -21,6 +21,7 @@ class State {
     var lastDateKey;       // yyyymmdd
     var dateStr;           // MAI null
     var weekdayIndex;      // 0..6
+    var lastDateCheckTs;   // ms — throttle for Time.Gregorian.info()
 
     // ----------------------------
     // Battery core
@@ -81,9 +82,10 @@ class State {
         lastMinuteKey = -1;
         timeStr       = TIME_FALLBACK;
 
-        lastDateKey   = 0;
-        dateStr       = DATE_FALLBACK;
-        weekdayIndex  = 0;
+        lastDateKey      = 0;
+        dateStr          = DATE_FALLBACK;
+        weekdayIndex     = 0;
+        lastDateCheckTs  = 0;
 
         // battery core
         lastBatteryTs     = 0;

--- a/source/manager/DataManager.mc
+++ b/source/manager/DataManager.mc
@@ -9,6 +9,7 @@ class DataManager {
     const BAT_REFRESH_MS    = 15 * 60 * 1000; // 15 min (sampling batteria + trend)
     const HEADER_REFRESH_MS = 60 * 60 * 1000; // 60 min (Last charge elapsed)
     const CHG_REFRESH_MS = 5 * 60 * 1000; // 5 min (charging state)
+    const DATE_REFRESH_MS = 60 * 60 * 1000; // 1h baseline; midnight window forces extra checks
     // Top2 mode (decidi tu dove settarlo: settings o default nello State)
     const TOP2_TTE = 0;
     const TOP2_EFF = 1;
@@ -32,15 +33,15 @@ class DataManager {
             }
         } catch(e) {}
 
-        // Date iniziale
-        refreshDateIfNeeded();
+        // Date iniziale (forced: lastDateCheckTs == 0)
+        refreshDateIfNeeded(System.getTimer());
     }
 
     public function getBatteryRefreshMs() { return BAT_REFRESH_MS; }
 
     // chiamala ad ogni onUpdate (economica)
     function refreshFast(nowMs) {
-        refreshDateIfNeeded();
+        refreshDateIfNeeded(nowMs);
 
         // 1) Charging state ogni 5 minuti (low cost)
         refreshChargingIfNeeded(nowMs);
@@ -81,6 +82,10 @@ class DataManager {
             }
         } catch(e) { }
 
+        // Mark charging as just-checked so refreshChargingIfNeeded skips its
+        // next tick — the stats read above already covers it.
+        _state.lastChargingCheckTs = nowMs;
+
         // ----------------------------
         // 2) Charging transitions (inizio/fine carica)
         // ----------------------------
@@ -110,7 +115,24 @@ class DataManager {
     // ----------------------------
     // DATE + WEEKDAY (solo cambio giorno)
     // ----------------------------
-    function refreshDateIfNeeded() {
+    function refreshDateIfNeeded(nowMs) {
+
+        // Throttle: skip Time.Gregorian.info() unless first call,
+        // ≥ DATE_REFRESH_MS elapsed, or we are in the midnight window.
+        if (_state.lastDateCheckTs != 0 &&
+            (nowMs - _state.lastDateCheckTs) < DATE_REFRESH_MS) {
+
+            var ct = System.getClockTime();
+            var inMidnightWindow =
+                (ct.hour == 23 && ct.min >= 58) ||
+                (ct.hour == 0  && ct.min <= 2);
+
+            if (!inMidnightWindow) {
+                return;
+            }
+        }
+
+        _state.lastDateCheckTs = nowMs;
 
         var dinfo = Time.Gregorian.info(Time.now(), Time.FORMAT_SHORT);
 


### PR DESCRIPTION
## Summary

Closes #25.

Pure CPU optimization in `DataManager`. **No user-visible behavior changes** — same detection latencies, same refresh cadences, same date-change semantics.

Two independent sub-tasks bundled in a single commit (both touch the same hot path).

### Sub-task 1 — Dedupe `System.getSystemStats()`

`refreshBatteryIfNeeded` already reads `charging` from `System.getSystemStats()`. After the read, we now mark `_state.lastChargingCheckTs = nowMs` so the next `refreshChargingIfNeeded` tick is skipped by its existing throttle (instead of issuing a second redundant `getSystemStats()` call).

**Savings**: 16 → 12 `getSystemStats()` calls per hour (−25%).

### Sub-task 2 — Throttle `refreshDateIfNeeded`

`Time.Gregorian.info()` was being called on every `onUpdate` (1440 times/day) only to detect the day rollover (1 time/day). Added a 1-hour baseline throttle plus a "midnight window" (23:58–00:02) that forces extra checks so the date update at midnight is preserved.

The midnight window check uses `System.getClockTime()`, which is much cheaper than `Time.Gregorian.info()`.

**Savings**: ~1440 → ~24 `Time.Gregorian.info()` calls per day (−98%).

### What did NOT change

- Battery sample throttle (15 min), header throttle (60 min), charging throttle (5 min) — all unchanged
- AOD pixel shift, dirty flags, partial redraw system — untouched
- "Since charge" feature — untouched
- All renderers and `State` contract — untouched
- Date update still happens at the minute of midnight

## Behavior preservation table

| Behavior | Before | After |
|---|---|---|
| Plug/unplug detection | ≤5 min | ≤5 min |
| "Since charge" timer accuracy | ±5 min | ±5 min |
| `Crg: …` (top2 in charging) | refreshed every minute | refreshed every minute |
| Battery `%` and `Δ%/h` updates | every 15 min | every 15 min |
| Date string update | at midnight minute | at midnight minute |

## Quality gate report

Tests executed (after rebase on `develop` containing the #27 fix):
- ✅ Build successful (exit 0, no warnings)
- ✅ Run cold start: simulator launched, watchface loaded, no crash
- ✅ Run warm start: auto-launch correctly skipped, watchface reloaded, no crash
- ✅ No new compiler warnings

⚠️ **Visual verification required by Matteo before merge**: please confirm in the simulator that all visible elements (time, date, header, top1, top2, footer) render and update as before — this PR is a behavior-preserving refactor, so any visible difference is a regression.

## Test plan

- [ ] Cold start: watchface renders, all sections present
- [ ] Wait for the next minute tick: time updates, no flicker
- [ ] Plug charger: within ≤5 min, charging state is detected (TOP2 shows `Crg:` if in CHG mode)
- [ ] Unplug charger: within ≤5 min, "Since charge" header transitions from `--` to elapsed time
- [ ] Leave running across midnight (or simulate): date string updates at the rollover minute

## History

- The original quality gate of this branch surfaced a pre-existing crash bug at cold start, which was triaged into #26 and fixed in #27 (now merged into `develop`). This branch is rebased on top of that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)