### PR TITLE
fix(ui): clip FULL_REDRAW clear to exclude left flashlight slider area

### DIFF
--- a/source/core/BatterySafeView.mc
+++ b/source/core/BatterySafeView.mc
@@ -113,7 +113,11 @@ class BatterySafeView extends WatchUi.WatchFace {
             if (_state.needsFullRedraw) {
 
                 dc.setColor(Graphics.COLOR_BLACK, Graphics.COLOR_BLACK);
-                dc.clear();
+                // Diagnostic clip for issue #31: avoid clearing the leftmost
+                // strip where OS flashlight intensity slider is rendered.
+                // Section drawStatic calls will repaint this area normally.
+                var sFull = GraphicsManager.getScale(dc);
+                dc.fillRectangle(40 * sFull, 0, dc.getWidth() - 40 * sFull, dc.getHeight());
 
                 GraphicsManager.drawHeader(dc, _state);
                 GraphicsManager.drawTopCenter(dc, _state);


### PR DESCRIPTION
Closes #34. Refs #31.

## Summary

Diagnostic fix for the flashlight intensity slider duplication bug on `epix2pro42mm` (issue #31). Replaces the full-screen `dc.clear()` in the FULL_REDRAW branch of `onUpdate` (`BatterySafeView.mc:116`) with a clipped `fillRectangle` that leaves a `40 * s` wide vertical strip on the left edge untouched — exactly where the OS flashlight slider is rendered.

The section `drawStatic` calls in each renderer continue to repaint their own areas (header top, mid centre, footer bottom) on the next FULL_REDRAW, so the watchface still renders correctly: only the leftmost narrow strip is left to the OS compositor.

## Hypothesis under test (H6')

> The full-screen `dc.clear()` at `BatterySafeView.mc:116` is the trigger of the duplicate-curve overlay bug. The OS draws the flashlight intensity slider on the left edge; when the watchface clears that region, the firmware repaints it and the repaint is not pixel-stable.

This is the most chirurgical remaining hypothesis after:
- Round 1's "onPartialUpdate is the trigger" was falsified by hardware test (PR #33 → bug persisted).
- Round 2 + post-A0 update narrowed the suspect list to **H6** (system invokes `onShow` on overlay open) and **H4** (pure firmware compositor bug). H6 was refined to **H6'** to isolate the actual draw call rather than the OS event.

See the [investigation report on #31](https://github.com/mdeias/BatterySafe/issues/31) for the full hypothesis tree and ranking.

## Diagnostic-fix rationale

If hardware test resolves the bug, this is the final fix. If not, we revert and the next step is determined by which sub-hypothesis remains. Three possible outcomes:

| Hardware test (T1+T2) | Conclusion | Next action |
|---|---|---|
| **Duplicate gone** | H6' confirmed: the `dc.clear()` was the trigger. | Merge as final fix. Close #31, #34. |
| **Duplicate persists** | H6' falsified: trigger is somewhere else (likely `drawStatic` of MidCenterRender or FooterRenderer, both full-width fillRectangle on the band where the slider sits). | Revert this PR. Open follow-up: either A1 (diagnostic logging) or F2 (clip-aware drawStatic refactor). |
| **Different visual artefact** | New evidence not anticipated by current hypothesis tree. | Revert and re-investigate. |

## Repro steps for hardware test (Matteo)

On `epix2pro42mm` with this branch installed:

- **T1 (screen awake)**: bring the watchface to awake mode (tap or wrist gesture), wait 2-3 seconds, then double-click LIGHT to activate the flashlight. Observe whether the duplicate appears.
- **T2 (screen off)**: wait until the screen turns fully off (with AOD disabled, this is the standard non-AOD low-power state), then double-click LIGHT to activate the flashlight from screen-off. Observe whether the duplicate appears.

If both T1 and T2 show no duplicate → H6' confirmed.
If either still shows the duplicate → H6' falsified.

## Why `40 * s`

The OS flashlight intensity slider on `epix2pro42mm` is a vertical control on the left edge. The exact width is not documented in CIQ; `40 * s` (≈ 43 px on this device, since `s = 416/390 ≈ 1.067`) is a conservative reserve estimate. If hardware test shows the duplicate is *partially* clipped (i.e. trigger area is wider than 40·s), we increase the strip width and re-test before declaring H6' falsified.

## Diff

Single-line change in `source/core/BatterySafeView.mc`, FULL_REDRAW branch only:

```diff
                 dc.setColor(Graphics.COLOR_BLACK, Graphics.COLOR_BLACK);
-                dc.clear();
+                // Diagnostic clip for issue #31: avoid clearing the leftmost
+                // strip where OS flashlight intensity slider is rendered.
+                // Section drawStatic calls will repaint this area normally.
+                var sFull = GraphicsManager.getScale(dc);
+                dc.fillRectangle(40 * sFull, 0, dc.getWidth() - 40 * sFull, dc.getHeight());
```

No other code modified. AOD branch (line 54), `onPartialUpdate` (no-op from PR #33), `onShow`, and renderer `drawStatic` calls are all untouched.

## Quality gate report

- ✅ Build successful via `./build.sh` (epix2pro42mm), no new compiler warnings.
- ✅ Run cold start (simulator launched, watchface loaded, exit 0).
- ✅ Run warm start (auto-launch skipped as expected, watchface reloaded, exit 0).
- ✅ Regression check: watchface rendering correct in simulator, all four sections visible, no garbage on left edge after first FULL_REDRAW (in simulator the flashlight is hardware-only and not present, so the visible test is just "watchface still works").

⚠️ **Visual verification required by Matteo before merge** — please run this branch on `epix2pro42mm` and execute T1 + T2 above. The simulator cannot reproduce the bug (no LED).

## Test plan

- [ ] Matteo flashes `fix/34-clip-fullredraw-clear` on `epix2pro42mm`.
- [ ] T1 (awake-mode flashlight activation): duplicate gone? yes / no.
- [ ] T2 (screen-off flashlight activation): duplicate gone? yes / no.
- [ ] Confirm watchface still renders correctly in normal use (no missing left edge artefacts).
- [ ] If T1+T2 both pass → merge to develop, close #31, close #34.
- [ ] If either fails → revert PR, post outcome on #31, decide between A1 (logging) or F2 (drawStatic refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)