### PR TITLE
feat(ui): add extreme power saver mode toggle in settings

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -5,5 +5,7 @@
     <property id="primaryColor" type="number">3</property>
     <property id="accentColor" type="number">1</property>
     <property id="top2Mode" type="number">1</property>
-    
+
+    <property id="extremePowerSaver" type="boolean">false</property>
+
 </properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -33,5 +33,8 @@
         </settingConfig>
     </setting>
 
+    <setting propertyKey="@Properties.extremePowerSaver" title="@Strings.ExtremePowerSaverTitle">
+        <settingConfig type="boolean" />
+    </setting>
 
 </settings>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -5,6 +5,7 @@
     <string id="BackgroundColorTitle">Background Color</string>
     <string id="ForegroundColorTitle">Foreground Color</string>
     <string id="MilitaryFormatTitle">Military Format for 24 Hour Time</string>
+    <string id="ExtremePowerSaverTitle">Extreme power saver</string>
 
     <string id="ColorBlack">Black</string>
     <string id="ColorDarkGray">Dark Gray</string>

--- a/source/core/BatterySafeView.mc
+++ b/source/core/BatterySafeView.mc
@@ -46,7 +46,11 @@ class BatterySafeView extends WatchUi.WatchFace {
     function onUpdate(dc as Dc) as Void {
 
         try {
-            if (_isLowPower) {
+            // Apply settings before branching so that toggling
+            // extremePowerSaver at runtime takes effect immediately.
+            applySettingsIfNeeded();
+
+            if (_isLowPower || Prefs.extremePowerSaver) {
                 _didDrawAod = true;
                 var s = GraphicsManager.getScale(dc);
                 var nowMs = System.getTimer();
@@ -57,7 +61,6 @@ class BatterySafeView extends WatchUi.WatchFace {
                 GraphicsManager.drawAodDate(dc, _state, _aodShiftX, _aodShiftY);
                 return;
             }
-            applySettingsIfNeeded();
             var nowMs = System.getTimer();
             // -----------------------------
             // Refresh dati (scheduler)

--- a/source/utils/Prefs.mc
+++ b/source/utils/Prefs.mc
@@ -3,7 +3,8 @@ using Toybox.Application;
 module Prefs {
 
     var use24h = true;
-    var top2Mode = 1; 
+    var top2Mode = 1;
+    var extremePowerSaver = false;
 
     function load() {
         var app = Application.getApp();
@@ -22,5 +23,8 @@ module Prefs {
         } else {
             top2Mode = 1;
         }
+
+        var eps = app.getProperty("extremePowerSaver");
+        extremePowerSaver = (eps != null && eps == true);
     }
 }


### PR DESCRIPTION
## Summary

Closes #36.

Adds a user-controlled boolean setting `extremePowerSaver` that forces the existing AOD/low-power render path (time + date + 10-min anti-burn-in pixel shift) to remain active **even when the device is awake**. Trades visual richness for maximum battery autonomy, on explicit opt-in.

## Changes

### Resources
- `resources/settings/properties.xml`: new `extremePowerSaver` boolean property, default `false`.
- `resources/settings/settings.xml`: new boolean setting backed by `@Strings.ExtremePowerSaverTitle`.
- `resources/strings/strings.xml`: new `ExtremePowerSaverTitle` = `Extreme power saver`.

### Source
- `source/utils/Prefs.mc`: new module variable `extremePowerSaver` (default `false`), loaded defensively (mirrors the `null`-safe pattern used for `UseMilitaryFormat`).
- `source/core/BatterySafeView.mc`:
  - `applySettingsIfNeeded()` is now called **at the top of `onUpdate`**, before the AOD branch check. Required so that toggling the setting at runtime takes effect at the next update tick without waiting for the watchface to first fall out of the AOD branch.
  - The AOD branch condition changed from `if (_isLowPower)` to `if (_isLowPower || Prefs.extremePowerSaver)`.
  - `onPartialUpdate` left untouched — it is already a no-op since #33, which is correct for the extreme saver state as well (no extra draws).

### Notes on the chosen condition

The OR-condition (`_isLowPower || Prefs.extremePowerSaver`) keeps the existing sleep-driven AOD path 1:1. The pixel-shift schedule (`updateAodShift`, 4 slots over 40 minutes) keeps running in the awake-forced state by design — confirmed with the user. No new draw primitives, no new system calls in the OFF path: `applySettingsIfNeeded` early-returns on unchanged `SettingsBus.version`.

## Quality gate report

Tests executed:
- ✅ Build successful (`./build.sh` exit 0, `BatterySafe-epix2pro42mm.prg` created, no compiler warnings)
- ✅ Run (`./run.sh` exit 0, simulator auto-launched from cold, watchface loaded)
- ⚠️ Visual verification deferred to Matteo (see Test plan below)

No new warnings detected. No regression expected in the OFF path (default).

## Test plan

⚠️ **Visual verification required by Matteo before merge.**

- [ ] Cold start with toggle OFF (default): watchface renders full layout as on `develop`.
- [ ] Open Connect IQ simulator → Settings → flip `Extreme power saver` to ON: at the next minute tick the watchface switches to the AOD-style render (black background, time + date only) while the device is awake.
- [ ] Flip toggle ON → OFF while awake: watchface returns to the full layout cleanly, no ghost residue.
- [ ] Flip toggle OFF → ON while awake: watchface clears and shows only AOD content, no full-layout pixels left behind.
- [ ] With toggle ON, simulate sleep/wake: behavior remains AOD throughout (no regression on existing sleep path).
- [ ] With toggle OFF, simulate sleep/wake: behavior identical to current `develop` (no regression).

## Out of scope

- Automatic activation under a battery threshold (possible follow-up).
- Hardware-button activation (not feasible on Connect IQ watchfaces — no key events).
- Any change to `DataManager` / `State` contract.
- A variant render without pixel shift in awake-forced state — the user confirmed shift stays on.

## Related

- Closes #36
- Builds on #33 (`onPartialUpdate` no-op), already merged into `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)