### PR TITLE
fix(data): track charge end as epoch and persist while charging (#39)

### DIFF
--- a/source/core/State.mc
+++ b/source/core/State.mc
@@ -39,9 +39,9 @@ class State {
     var lastBattSampleTs;  // ms
     var lastRatePerHour;   // Float (può essere null)  <-- NECESSARIA
 
-    var chargeStartTs;     // ms (quando entra charging=true)
-    var lastChargeEndTs;   // ms (quando esce charging=false)
-    var lastChargeDurMs;   // ms (durata ultima sessione di carica)
+    var chargeStartTs;       // ms (quando entra charging=true)
+    var lastChargeEndEpoch;  // epoch sec (fine ultima carica; 0 = sconosciuto)
+    var lastChargeDurMs;     // ms (durata ultima sessione di carica)
 
     // Header refresh throttle
     var lastHeaderTs;      // ms
@@ -99,9 +99,9 @@ class State {
         lastBattSampleTs  = 0;
         lastRatePerHour   = null;
 
-        chargeStartTs     = 0;
-        lastChargeEndTs   = 0;
-        lastChargeDurMs   = 0;
+        chargeStartTs      = 0;
+        lastChargeEndEpoch = 0;
+        lastChargeDurMs    = 0;
 
         lastHeaderTs      = 0;
         lastChargingCheckTs = 0;

--- a/source/manager/DataManager.mc
+++ b/source/manager/DataManager.mc
@@ -20,16 +20,14 @@ class DataManager {
     function initialize(state as State) {
         _state = state;
 
-        // Restore lastChargeEndTs across reloads: stored as epoch (seconds),
-        // converted back to System.getTimer() units on resume.
+        // Restore last charge end across reloads. Kept as epoch seconds end
+        // to end: no System.getTimer() conversion, so no 32-bit ms overflow
+        // and no timer-wrap issues for long elapsed times.
         try {
             var storedEpoch = Application.Storage.getValue("lastChargeEndEpoch");
-            if (storedEpoch != null) {
-                var nowMs = System.getTimer();
-                var elapsedMs = (Time.now().value() - storedEpoch) * 1000;
-                if (elapsedMs > 0 && elapsedMs < 20 * 24 * 3600 * 1000) {
-                    _state.lastChargeEndTs = nowMs - elapsedMs;
-                }
+            if (storedEpoch != null && storedEpoch > 0 &&
+                storedEpoch <= Time.now().value()) {
+                _state.lastChargeEndEpoch = storedEpoch;
             }
         } catch(e) {}
 
@@ -179,26 +177,36 @@ class DataManager {
             _state.charging = chargingNow;
             if (chargingNow) {
                 _state.chargeStartTs = nowMs;
+                _persistChargeEndEpoch(Time.now().value());
             }
             return;
         }
 
         if (chargingNow == _state.charging) {
+            // While charging, keep the persisted epoch close to "now": if the
+            // unplug transition is never observed (app unloaded/restarted),
+            // the stored value still approximates the charge end on next
+            // launch. Piggybacks on the existing throttled checks, and the
+            // device is on power while these writes happen.
+            if (chargingNow) {
+                _persistChargeEndEpoch(Time.now().value());
+            }
             return;
         }
 
         // transizione
-        var old = _state.charging;
         _state.charging = chargingNow;
 
         if (chargingNow) {
             // entra in charging
             _state.chargeStartTs = nowMs;
+            _persistChargeEndEpoch(Time.now().value());
 
         } else {
             // esce da charging (unplug)
-            _state.lastChargeEndTs = nowMs;
-            Application.Storage.setValue("lastChargeEndEpoch", Time.now().value());
+            var nowEpoch = Time.now().value();
+            _state.lastChargeEndEpoch = nowEpoch;
+            _persistChargeEndEpoch(nowEpoch);
 
             if (_state.chargeStartTs != 0 && nowMs > _state.chargeStartTs) {
                 _state.lastChargeDurMs = nowMs - _state.chargeStartTs;
@@ -208,6 +216,12 @@ class DataManager {
             // forza header refresh immediato
             _state.lastHeaderTs = 0;
         }
+    }
+
+    function _persistChargeEndEpoch(epoch) {
+        try {
+            Application.Storage.setValue("lastChargeEndEpoch", epoch);
+        } catch(e) { }
     }
 
     // ----------------------------
@@ -292,8 +306,13 @@ class DataManager {
 
         var s = "Since charge: --";
 
-        if (_state.lastChargeEndTs != 0 && nowMs > _state.lastChargeEndTs) {
-            s = "Since charge: " + _fmtDH(nowMs - _state.lastChargeEndTs);
+        // Elapsed computed in epoch seconds: immune to System.getTimer()
+        // wrap and to 32-bit overflow on long gaps between charges.
+        if (_state.lastChargeEndEpoch != 0) {
+            var elapsedSec = Time.now().value() - _state.lastChargeEndEpoch;
+            if (elapsedSec >= 0) {
+                s = "Since charge: " + _fmtDHFromSec(elapsedSec);
+            }
         }
 
         if (_state.headerStr != s) {
@@ -381,7 +400,11 @@ class DataManager {
     // ----------------------------
     function _fmtDH(ms) {
         if (ms <= 0) { return "--"; }
-        var sec = (ms / 1000).toNumber();
+        return _fmtDHFromSec((ms / 1000).toNumber());
+    }
+
+    function _fmtDHFromSec(sec) {
+        if (sec < 0) { return "--"; }
         var min = (sec / 60).toNumber();
         var hr  = (min / 60).toNumber();
         var day = (hr / 24).toNumber();


### PR DESCRIPTION
## Summary

Fixes the "Since charge" header staying at `--` after a charge completes (#39).

Root causes addressed:

1. **Missed unplug transition**: the charge-end epoch was only written to Storage when the running watchface directly observed the charging→not-charging transition. Now the epoch is persisted on every throttled charging check **while charging is observed**, so if the app is unloaded/restarted before the unplug, the last stored value still approximates the charge end on next launch. No new timers or extra `getSystemStats()` calls — it piggybacks on the existing 5-min check, and the device is on external power during these writes.
2. **32-bit overflow in the restore path**: `(Time.now().value() - storedEpoch) * 1000` overflowed for gaps > ~24.8 days before the 20-day guard could reject them. The elapsed time is now computed end-to-end in epoch seconds (`State.lastChargeEndTs` ms replaced by `State.lastChargeEndEpoch`), which also removes any `System.getTimer()` wrap concern for the header.
3. **Value regression**: the restore path no longer discards stored values older than 20 days; it only sanity-checks that the epoch is positive and not in the future, so the label never regresses to `--` once a charge end has been recorded.

Out of scope (unchanged): `HEADER_REFRESH_MS` cadence, `Crg:` top-line-2 mode (still `getTimer()`-based for in-session duration), header UI/layout.

## Quality gate report

Tests executed:
- ✅ Build successful (exit 0, `BatterySafe-epix2pro42mm.prg` created, `BUILD SUCCESSFUL`)
- ✅ Run cold start (simulator auto-launched, watchface loaded, no crash after 10s)
- ✅ Run warm start (auto-launch skipped, watchface reloaded, no crash after 10s)
- ✅ No new compiler warnings (0 on branch vs 0 on develop)
- ✅ Regression check (watchface runs normally with empty/legacy Storage state; header falls back to `--` only on genuine first-install)
- ⚠️ Scenario tests (plug/unplug transitions, app restart while charging) require interactive simulator controls — manual verification needed

⚠️ **Visual verification required by Matteo before merge**: please confirm in the simulator that the header renders correctly, and exercise the charging scenarios via Simulation → Battery (plug, unplug, restart while charging) to verify the elapsed label updates as expected.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)