### PR TITLE
fix(ui): black left strip on partial redraw to clear stale overlay (#43)

### DIFF
--- a/source/core/BatterySafeView.mc
+++ b/source/core/BatterySafeView.mc
@@ -131,6 +131,18 @@ class BatterySafeView extends WatchUi.WatchFace {
             // -----------------------------
             // PARTIAL REDRAW (solo sezioni dirty)
             // -----------------------------
+
+            // Diagnostic for #31 (hypothesis H7): the Dc can carry the
+            // current screen content, OS flashlight slider included. A
+            // partial redraw would present those stale slider pixels back
+            // to the screen while the OS composites its live slider on
+            // top, producing the ghost duplicate. Black out the left-edge
+            // strip where the slider lives (no watchface content there)
+            // before drawing the dirty sections.
+            var scale = GraphicsManager.getScale(dc);
+            dc.setColor(Graphics.COLOR_BLACK, Graphics.COLOR_BLACK);
+            dc.fillRectangle(0, 120.0 * scale, 60.0 * scale, 190.0 * scale);
+
             if (_state.dirtyHeader) {
                 GraphicsManager.drawHeader(dc, _state);
             }


### PR DESCRIPTION
## Summary

Diagnostic fix for #31, implementing #43 — hypothesis **H7 (stale baked overlay pixels)**: the `Dc` received in `onUpdate` can carry the current screen content, OS flashlight slider included. Partial redraws repaint only dirty sections, so a stale snapshot of the slider survives in the presented frame; the OS composites its live slider on top with a slight offset, producing the ghost duplicate.

H7 is the first hypothesis consistent with all eight data points collected across rounds 1-4, including the two new control tests (another full-redraw CIQ watchface: no ghost; extreme power saver mode: no ghost) and the failure of PR #35 (preserving the left strip preserved the fossil pixels — the fix direction was inverted).

Change (single commit, one file, +12 lines, trivially revertable):
- At the start of the PARTIAL REDRAW branch in `BatterySafeView.onUpdate`, fill the left-edge strip x ∈ [0, 60·s], y ∈ [120·s, 310·s] with black, before drawing the dirty sections. The strip sits between the header and footer bands where no watchface content lives.
- FULL_REDRAW (already a full `dc.clear()`), AOD/extreme branch, `onShow`, `onPartialUpdate`, renderers: untouched.

Power budget: one black `fillRectangle` (~13k px) per partial-redraw pass, max once per minute, inside the existing draw cycle. No new timers, sensors, Storage, or cadence changes; black = pixels off on AMOLED.

## Hardware test protocol (Matteo, on epix2pro42mm)

- **T1**: screen awake → activate flashlight → adjust intensity → observe slider for ~10s.
- **T2**: screen off → activate flashlight (wakes screen) → adjust intensity → observe ~10s.

Possible outcomes:
1. **Ghost gone (T1+T2)** → H7 confirmed. Merge this PR, close #31 referencing #43.
2. **Ghost reduced/clipped** → H7 confirmed, strip too narrow. Report which part of the slider still ghosts (top/bottom/right edge); follow-up commit widens the bounds.
3. **Ghost identical** → H7 falsified. Close this PR without merging, document on #31, fall back to A1 logging.

## Quality gate report

Tests executed:
- ✅ Build successful (exit 0, `BatterySafe-epix2pro42mm.prg` created, `BUILD SUCCESSFUL`)
- ✅ Run cold start (simulator auto-launched, watchface loaded, no crash after 10s)
- ✅ Run warm start (auto-launch skipped, watchface reloaded, no crash after 10s)
- ✅ No new compiler warnings (0 on branch)
- ⚠️ Reproducer scenario (flashlight overlay) is hardware-only — cannot be tested in the simulator

⚠️ **Visual verification required by Matteo before merge**: in the simulator, let the watchface sit across at least one minute change (so a partial redraw fires) and confirm there are no artifacts on the left edge and all 4 sections render correctly. Then run the hardware protocol above.

Refs #43, #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)