### PR TITLE
feat(ui): bright clock in extreme power saver + fix frozen time (#38)

### DIFF
--- a/source/Wrapper/GraphicsManager.mc
+++ b/source/Wrapper/GraphicsManager.mc
@@ -50,10 +50,10 @@ module GraphicsManager {
         _footerRenderer.draw(dc, state, s);
     }
 
-    function drawAodTime(dc as Graphics.Dc, state as State, shiftX, shiftY) {
+    function drawAodTime(dc as Graphics.Dc, state as State, shiftX, shiftY, bright) {
         if (_topCenterRenderer == null) { init(); }
         var s = getScale(dc);
-        _topCenterRenderer.drawAodTime(dc, state, s, shiftX, shiftY);
+        _topCenterRenderer.drawAodTime(dc, state, s, shiftX, shiftY, bright);
     }
 
     function drawAodDate(dc as Graphics.Dc, state as State, shiftX, shiftY) {

--- a/source/core/BatterySafeView.mc
+++ b/source/core/BatterySafeView.mc
@@ -50,6 +50,12 @@ class BatterySafeView extends WatchUi.WatchFace {
             // extremePowerSaver at runtime takes effect immediately.
             applySettingsIfNeeded();
 
+            // Refresh the cached time string before any draw branch: the
+            // AOD / extreme-power-saver path returns early, so if the time
+            // were only recomputed in the normal path below the clock would
+            // stay frozen in those modes.
+            refreshTimeString();
+
             if (_isLowPower || Prefs.extremePowerSaver) {
                 _didDrawAod = true;
                 var s = GraphicsManager.getScale(dc);
@@ -57,7 +63,11 @@ class BatterySafeView extends WatchUi.WatchFace {
                 dc.setColor(Graphics.COLOR_BLACK, Graphics.COLOR_BLACK);
                 dc.clear();
                 updateAodShift(nowMs, s);
-                GraphicsManager.drawAodTime(dc, _state, _aodShiftX, _aodShiftY);
+                // Bright primary-color time only for extreme power saver
+                // while awake; true AOD (_isLowPower) keeps the dim gray to
+                // save power on the always-on display.
+                var brightTime = !_isLowPower;
+                GraphicsManager.drawAodTime(dc, _state, _aodShiftX, _aodShiftY, brightTime);
                 GraphicsManager.drawAodDate(dc, _state, _aodShiftX, _aodShiftY);
                 return;
             }
@@ -78,26 +88,8 @@ class BatterySafeView extends WatchUi.WatchFace {
             }
 
 
-            // -----------------------------
-            // Time cache (solo se cambia minuto)
-            // -----------------------------
-            var ct = System.getClockTime();
-            var minuteKey = (ct.hour * 60) + ct.min;
-
-            if (minuteKey != _state.lastMinuteKey) {
-                _state.lastMinuteKey = minuteKey;
-
-                    var hh = ct.hour;
-
-                    if (!Prefs.use24h) {
-                        hh = hh % 12;
-                        if (hh == 0) { hh = 12; }
-                    }
-                    
-                    _state.timeStr = hh.format("%02d") + ":" + ct.min.format("%02d");
-
-                _state.dirtyTime = true;
-            }
+            // Time cache already refreshed above (refreshTimeString), before
+            // the AOD / extreme-power-saver branch.
 
             // Se non devo ridisegnare nulla, esco
             if (!_state.needsFullRedraw &&
@@ -207,6 +199,26 @@ class BatterySafeView extends WatchUi.WatchFace {
         dc.clear();
     }
 
+
+    // Recompute the minute-resolution cached time string. Cheap
+    // (System.getClockTime) and safe to call on every update, including the
+    // AOD / extreme-power-saver branch, so the clock never stays frozen.
+    function refreshTimeString() {
+        var ct = System.getClockTime();
+        var minuteKey = (ct.hour * 60) + ct.min;
+        if (minuteKey == _state.lastMinuteKey) { return; }
+
+        _state.lastMinuteKey = minuteKey;
+
+        var hh = ct.hour;
+        if (!Prefs.use24h) {
+            hh = hh % 12;
+            if (hh == 0) { hh = 12; }
+        }
+
+        _state.timeStr = hh.format("%02d") + ":" + ct.min.format("%02d");
+        _state.dirtyTime = true;
+    }
 
     function updateAodShift(nowMs, s) {
 

--- a/source/draw/TopCenterRender.mc
+++ b/source/draw/TopCenterRender.mc
@@ -146,7 +146,7 @@ class TopCenterRenderer {
     // ----------------------------
     // AOD: SOLO ORA (stessa posizione e dimensione del normale)
     // ----------------------------
-    function drawAodTime(dc as Graphics.Dc, state as State, s, shiftX, shiftY) {
+    function drawAodTime(dc as Graphics.Dc, state as State, s, shiftX, shiftY, bright) {
 
         // assicurati che layout sia pronto (usa lo stesso font/geo)
         if (_lastScale == null || _lastScale != s) {
@@ -154,8 +154,10 @@ class TopCenterRenderer {
             _lastScale = s;
         }
 
-        // ora
-        dc.setColor(Graphics.COLOR_DK_GRAY, Graphics.COLOR_TRANSPARENT);
+        // ora: verde acceso (primary) in extreme power saver da sveglio,
+        // grigio dim nell'AOD vero per risparmiare batteria.
+        var timeColor = bright ? Palette.PRIMARY : Graphics.COLOR_DK_GRAY;
+        dc.setColor(timeColor, Graphics.COLOR_TRANSPARENT);
         dc.drawText(
             _timeX + shiftX,
             _timeY + shiftY,


### PR DESCRIPTION
## Summary

Two fixes in the shared AOD / extreme-power-saver render branch of `BatterySafeView.onUpdate`.

### 1. Frozen clock in extreme power saver (bug)

The cached time string (`_state.timeStr`) was recomputed only in the normal `onUpdate` path, **after** the AOD / extreme-power-saver branch returns early. As a result the clock stayed frozen at the last awake value in extreme power saver mode (and, latently, in true AOD too).

Fix: extracted the minute-resolution recompute into `refreshTimeString()` and call it **before** the AOD/EPS branch. Cost is one extra `System.getClockTime()` per AOD tick — cheap, and the minimum needed to display the correct time. The duplicated time-cache block in the normal path is removed.

### 2. Time color in extreme power saver (#38)

The AOD/EPS branch always drew the time in `Graphics.COLOR_DK_GRAY`. Now:
- **Extreme power saver while awake** (`_isLowPower == false`): time drawn in `Palette.PRIMARY` (bright green by default, follows the user's `primaryColor` setting).
- **True AOD** (`_isLowPower == true`): unchanged, keeps `COLOR_DK_GRAY` to save power on the always-on display.

The `bright` flag is routed `BatterySafeView → GraphicsManager.drawAodTime → TopCenterRender.drawAodTime`, so the renderer still reads no `System`/`Prefs` state (layering contract preserved). AOD date color and the anti-burn-in pixel shift are untouched.

## Quality gate report

- ✅ Build successful — `./build.sh` equivalent for `epix2pro42mm` **and** `fenix847mm` (fēnix 8 AMOLED 47/51mm), `BUILD SUCCESSFUL`, no new warnings
- ✅ Run — new build loaded in the Connect IQ simulator on `fenix847mm`, cold start, no crash
- ✅ All `drawAodTime` call sites updated to the new signature (no stale callers)
- ⚠️ **Visual verification (Matteo)**: in the simulator, enable *Extreme power saver* while awake → time is bright green and advances each minute; simulate low-power/AOD → time is dim gray again (unchanged). Confirm pixel-shift still works in both.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)